### PR TITLE
Vagrant: use box canonical name rather than URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ installed-files.txt
 oonib.conf
 
 oonib.pid
+
+# Local vagrant files
+/.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "precise32"
-  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+  config.vm.box = "ubuntu/precise32"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,


### PR DESCRIPTION
This allows us to get updates running `vagrant box update`.

While at it, add `/.vagrant/` to `.gitignore`.