### PR TITLE
Move state of reports to the filesystem

### DIFF
--- a/oonib/api.py
+++ b/oonib/api.py
@@ -1,6 +1,5 @@
 from cyclone import web
 
-from oonib.bouncer.api import bouncerAPI
 
 from oonib.config import config
 
@@ -34,6 +33,8 @@ class OONICollector(web.Application):
 
 class OONIBouncer(web.Application):
     def __init__(self):
+        from oonib.bouncer.api import bouncerAPI
+
         handlers = []
         handlers += bouncerAPI
 

--- a/oonib/config.py
+++ b/oonib/config.py
@@ -8,11 +8,13 @@ import os
 
 
 class Config(object):
-    main = {}
-    helpers = {}
-    reports = {}
     backend_version = __version__
     opts = OONIBOptions()
+
+    def __init__(self):
+        self.main = Storage()
+        self.helpers = Storage()
+        self.reports = Storage()
 
     def load(self):
         self.opts.parseOptions()

--- a/oonib/oonibackend.py
+++ b/oonib/oonibackend.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 
-from oonib.api import ooniBackend, ooniBouncer
+from oonib.api import OONICollector, OONIBouncer
 from oonib.config import config
 from oonib.onion import get_global_tor
 from oonib.testhelpers import dns_helpers, ssl_helpers
@@ -64,9 +64,9 @@ def getEndpoint(endpoint_config):
 
 def createService(endpoint, role, endpoint_config):
     if role == 'bouncer':
-        factory = ooniBouncer
+        factory = OONIBouncer()
     elif role == 'collector':
-        factory = ooniBackend
+        factory = OONICollector()
     elif role == 'web_connectivity':
         factory = http_helpers.WebConnectivityHelper
     else:

--- a/oonib/report/handlers.py
+++ b/oonib/report/handlers.py
@@ -1,11 +1,11 @@
-import shutil
 import time
 import yaml
 import json
-import os
+import errno
 import re
 
-from twisted.internet import fdesc, reactor
+from twisted.python.filepath import FilePath, InsecurePath
+from twisted.internet import reactor
 
 from oonib import errors as e
 from oonib.handlers import OONIBHandler
@@ -16,7 +16,7 @@ from oonib import randomStr, otime, log, json_dumps
 from oonib.config import config
 
 
-def report_file_name(archive_dir, report_details,
+def report_file_path(archive_dir, report_details,
                      report_id='no_report_id'):
     if report_details.get("start_time"):
         timestamp = datetime.fromtimestamp(report_details['start_time'])
@@ -46,66 +46,14 @@ def report_file_name(archive_dir, report_details,
     report_file_template = "{iso8601_timestamp}-{test_name}-{report_id}-{probe_asn}-{probe_cc}-probe-0.2.0.{ext}"
     if config.main.get('report_file_template'):
         report_file_template = config.main['report_file_template']
-    dst_filename = os.path.join(archive_dir, report_file_template.format(**keys))
-    dst_dir = os.path.dirname(dst_filename)
-    if not os.path.exists(dst_dir):
-        os.makedirs(dst_dir)
-    return dst_filename
 
-
-class Report(object):
-    delayed_call = None
-
-    def __init__(self, report_id,
-                 stale_time,
-                 report_dir,
-                 archive_dir,
-                 reports,
-                 report_details):
-        self.report_id = report_id
-
-        self.report_details = report_details
-
-        self.stale_time = stale_time
-        self.report_dir = report_dir
-        self.archive_dir = archive_dir
-        self.reports = reports
-
-        self.refresh()
-
-    def refresh(self):
-        self.last_updated = time.time()
-        if self.delayed_call:
-            self.delayed_call.cancel()
-        self.delayed_call = reactor.callLater(self.stale_time,
-                                              self.stale_check)
-
-    def stale_check(self):
-        if (time.time() - self.last_updated) > self.stale_time:
-            try:
-                self.close()
-            except e.ReportNotFound:
-                pass
-
-    def close(self):
-        def get_report_path(report_id):
-            return os.path.join(self.report_dir, report_id)
-
-        report_filename = get_report_path(self.report_id)
-        try:
-            open(report_filename).close()
-        except IOError:
-            raise e.ReportNotFound
-
-        dst_filename = report_file_name(archive_dir=self.archive_dir,
-                                        report_details=self.report_details,
-                                        report_id=self.report_id)
-        shutil.move(report_filename, dst_filename)
-
-        if not self.delayed_call.called:
-            self.delayed_call.cancel()
-        del self.reports[self.report_id]
-
+    dst_path = archive_dir.child(report_file_template.format(**keys))
+    try:
+        FilePath(dst_path.dirname()).makedirs()
+    except OSError as e:
+        if not e.errno == errno.EEXIST:
+            raise
+    return dst_path
 
 def parseUpdateReportRequest(request, report_id=None):
     #db_report_id_regexp = re.compile("[a-zA-Z0-9]+$")
@@ -192,27 +140,63 @@ def parseNewReportRequest(request):
 
     return parsed_request
 
-class ReportHandler(OONIBHandler):
+def closeReport(report_id):
+    report_dir = FilePath(config.main.report_dir)
+    archive_dir = FilePath(config.main.archive_dir)
+    report_path = report_dir.child(report_id)
+    report_metadata_path = report_dir.child(report_id +
+                                            "-metadata.json")
+    print "Checking if %s exists and %s exists" % (report_path,
+                                                   report_metadata_path)
+    if not report_path.exists() or \
+            not report_metadata_path.exists():
+        raise e.ReportNotFound
 
+    with report_metadata_path.open('r') as f:
+        report_details = json.load(f)
+
+    dst_path = report_file_path(archive_dir,
+                                report_details,
+                                report_id)
+    if report_path.getsize() > 0:
+        report_path.moveTo(dst_path)
+    else:
+        # We currently just remove empty reports.
+        # XXX Maybe in the future we want to keep track of how often this
+        # happens.
+        report_path.remove()
+    report_metadata_path.remove()
+
+def checkForStaleReports():
+    report_dir = FilePath(config.main.report_dir)
+    for report_metadata_path in \
+            report_dir.globChildren("*-metadata.json"):
+        last_updated = time.time() - report_metadata_path.getModificationTime()
+        if last_updated > config.main.stale_time:
+            report_id = report_metadata_path.basename().replace(
+                '-metadata.json', '')
+            closeReport(report_id)
+    reactor.callLater(config.main.stale_time,
+                      checkForStaleReports)
+
+class ReportHandler(OONIBHandler):
     def initialize(self):
-        self.archive_dir = config.main.archive_dir
-        self.report_dir = config.main.report_dir
-        self.reports = config.reports
+        self.archive_dir = FilePath(config.main.archive_dir)
+        self.report_dir = FilePath(config.main.report_dir)
+
         self.policy_file = config.main.policy_file
         self.helpers = config.helpers
-        self.stale_time = config.main.stale_time
-
 
 class UpdateReportMixin(object):
     def updateReport(self, report_id, parsed_request):
 
         log.debug("Got this request %s" % parsed_request)
-        report_filename = os.path.join(self.report_dir,
-                                       report_id)
         try:
-            self.reports[report_id].refresh()
-        except KeyError:
-            raise e.OONIBError(404, "Report not found")
+            report_path = self.report_dir.child(report_id)
+            report_metadata_path = self.report_dir.child(report_id +
+                                                         '-metadata.json')
+        except InsecurePath:
+            raise e.OONIBError(406, "Invalid report_id")
 
         content_format = parsed_request.get('format', 'yaml')
         if content_format == 'json':
@@ -222,11 +206,16 @@ class UpdateReportMixin(object):
             data = parsed_request['content']
         else:
             raise e.InvalidFormatField
-        try:
-            with open(report_filename, 'a+') as fd:
-                fd.write(data)
-        except IOError:
+
+        if not report_path.exists() or \
+                not report_metadata_path.exists():
             raise e.OONIBError(404, "Report not found")
+
+        with report_path.open('a') as fd:
+            fd.write(data)
+
+        report_metadata_path.touch()
+
         self.write({'status': 'success'})
 
 
@@ -325,7 +314,11 @@ class NewReportHandlerFile(ReportHandler, UpdateReportMixin):
 
         # The report filename contains the timestamp of the report plus a
         # random nonce
-        report_filename = os.path.join(self.report_dir, report_id)
+        report_path = self.report_dir.child(report_id)
+        # We use this file to store the metadata associated with the report
+        # submission.
+        report_metadata_path = self.report_dir.child(report_id +
+                                                     "-metadata.json")
 
         response = {
             'backend_version': config.backend_version,
@@ -342,25 +335,16 @@ class NewReportHandlerFile(ReportHandler, UpdateReportMixin):
             except KeyError:
                 raise e.TestHelperNotFound
 
-        self.reports[report_id] = Report(report_id=report_id,
-            stale_time=self.stale_time,
-            report_dir=self.report_dir,
-            archive_dir=self.archive_dir,
-            reports=self.reports,
-            report_details=report_data
-        )
+        with report_metadata_path.open('w') as f:
+            f.write(json_dumps(report_data))
+            f.write("\n")
 
+        report_path.touch()
         if data is not None:
-            self.writeToReport(report_filename, data)
-        else:
-            open(report_filename, 'w+').close()
+            with report_path.open('w') as f:
+                f.write(data)
 
         self.write(response)
-
-    def writeToReport(self, report_filename, data):
-        with open(report_filename, 'w+') as fd:
-            fdesc.setNonBlocking(fd.fileno())
-            fdesc.writeToFD(fd.fileno(), data)
 
     def put(self):
         """
@@ -384,16 +368,11 @@ class UpdateReportHandlerFile(ReportHandler, UpdateReportMixin):
 
 
 class CloseReportHandlerFile(ReportHandler):
-
     def get(self):
         pass
 
     def post(self, report_id):
-        if report_id in self.reports:
-            self.reports[report_id].close()
-        else:
-            raise e.ReportNotFound
-
+        closeReport(report_id)
 
 class PCAPReportHandler(ReportHandler):
 

--- a/oonib/test/handler_helpers.py
+++ b/oonib/test/handler_helpers.py
@@ -1,7 +1,8 @@
 import sys
 import os
-import socket
 import json
+import time
+import socket
 import shutil
 
 from twisted.python.filepath import FilePath
@@ -61,6 +62,7 @@ class HandlerTestCase(unittest.TestCase):
             self._listener = reactor.listenTCP(self.port, self.app)
         config.main.report_dir = "."
         config.main.archive_dir = "."
+        config.main.stale_time = 100
         return super(HandlerTestCase, self).setUp()
 
     def tearDown(self):
@@ -83,3 +85,13 @@ class HandlerTestCase(unittest.TestCase):
                                           postdata=postdata,
                                           headers=headers)
         defer.returnValue(response)
+
+class MockTime(object):
+    def __init__(self):
+        self._offset = 0
+
+    def advance(self, seconds):
+        self._offset += seconds
+
+    def time(self):
+        return time.time() + self._offset

--- a/oonib/test/handler_helpers.py
+++ b/oonib/test/handler_helpers.py
@@ -4,6 +4,7 @@ import socket
 import json
 import shutil
 
+from twisted.python.filepath import FilePath
 from twisted.internet import reactor, defer
 from twisted.trial import unittest
 
@@ -19,13 +20,10 @@ def random_unused_port(bind_address='127.0.0.1'):
     s.close()
     return port
 
-reports = {}
-
 
 def mock_initialize(self):
-    self.report_dir = '.'
-    self.archive_dir = '.'
-    self.reports = reports
+    self.report_dir = FilePath('.')
+    self.archive_dir = FilePath('.')
     self.policy_file = None
     self.helpers = {}
     self.stale_time = 10
@@ -61,6 +59,8 @@ class HandlerTestCase(unittest.TestCase):
             config.load()
         if self.app:
             self._listener = reactor.listenTCP(self.port, self.app)
+        config.main.report_dir = "."
+        config.main.archive_dir = "."
         return super(HandlerTestCase, self).setUp()
 
     def tearDown(self):
@@ -71,11 +71,6 @@ class HandlerTestCase(unittest.TestCase):
         for dir in self.directories:
             shutil.rmtree(dir)
         if self._listener:
-            for report in reports.values():
-                try:
-                    report.delayed_call.cancel()
-                except:
-                    pass
             self._listener.stopListening()
 
     @defer.inlineCallbacks


### PR DESCRIPTION
This implements one of the solutions outlined in #86 to support saving the state of a ooni-backend instance when it is shutdown.

Basically we have two files for an opened report with ID `$REPORT_ID` they both reside in the `$REPORTS_DIR`.

1. The file at the path `$REPORTS_DIR/$REPORT_ID` is the actual partial report, that get's updated every time we need to create a new entry. 

2. The file at the path `$REPORTS_DIR/$REPORT_ID-metadata.json` contains the metadata associated with this report (the metadata sent on `open()`).

Every time we get a new update request we append to file 1. and touch file 2.

At regular intervals we look inside of the `$REPORTS_DIR` for all files ending with `-metadata.json` and look at their `mtime` with `stat`. If they have not been modified in a time frame greater than the stale_time we consider them stale and close them.