### PR TITLE
Add support for specifying the collector-alternate field

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,6 +179,18 @@ This can be specified like follows::
             - {address: 'http://web-connectivity.ooni.io', type: 'http'}
 
 
+Also collectors can have a set of alternate addresses. These can be
+specified inside of the `collector-alternate` key under the collector
+address like so::
+
+     collector:
+      httpo://thirteenchars123.onion:
+        collector-alternate:
+        - {address: 'https://a.collector.ooni.io', type: 'https'}
+        - {address: 'http://a.collector.ooni.io', type: 'http'}
+
+The currently supported types are 'https' and 'http'.
+
 Generate self signed certs for OONIB
 ....................................
 If you want to use the HTTPS test helper, you will need to create a

--- a/oonib/bouncer/handlers.py
+++ b/oonib/bouncer/handlers.py
@@ -160,8 +160,8 @@ class Bouncer(object):
                 requested_nettest['test-helpers'])
             test_helpers = {}
             test_helpers_alternate = {}
+            collector_info = self.bouncerFile['collector'][collector]
             for test_helper in requested_nettest['test-helpers']:
-                collector_info = self.bouncerFile['collector'][collector]
                 try:
                     test_helpers[test_helper] = \
                         collector_info['test-helper'][test_helper]
@@ -184,7 +184,8 @@ class Bouncer(object):
                 'input-hashes': requested_nettest['input-hashes'],
                 'test-helpers': test_helpers,
                 'test-helpers-alternate': test_helpers_alternate,
-                'collector': collector
+                'collector': collector,
+                'collector-alternate': collector_info.get('collector-alternate', [])
             }
             nettests.append(nettest)
         return {'net-tests': nettests}

--- a/oonib/test/test_bouncer.py
+++ b/oonib/test/test_bouncer.py
@@ -32,6 +32,9 @@ collector:
     test-helper: {fake_test_helper: 'fake_hostname'}
   default_collector:
     test-helper: {fake_test_helper: 'fake_hostname'}
+    collector-alternate:
+    - {address: 'https://a.collector.ooni.io', type: 'https'}
+    - {address: 'http://a.collector.ooni.io', type: 'http'}
 """
 
 fake_bouncer_file_multiple_collectors = """
@@ -373,6 +376,14 @@ class TestDefaultCollector(BaseTestBouncer):
         self.assertIn('collector', response_body['net-tests'][0])
         self.assertEqual(response_body['net-tests'][0]['collector'], 'default_collector')
 
+        self.assertIn('collector-alternate', response_body['net-tests'][0])
+        collector_alternate = response_body['net-tests'][0]['collector-alternate']
+        self.assertEqual(collector_alternate[0],
+                         {'type': 'https', 'address':
+                             'https://a.collector.ooni.io'})
+        self.assertEqual(collector_alternate[1],
+                         {'type': 'http', 'address':
+                             'http://a.collector.ooni.io'})
 
 class TestMultipleCollectors(BaseTestBouncer):
     app = web.Application(bouncerAPI, name='bouncerAPI')


### PR DESCRIPTION
Through this it is possible to specify HTTPS and cloudfronted collectors