### PR TITLE
Implement fix to serve also intermediate certificates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,12 +113,12 @@ Configure bouncer and collector endpoints
 The bouncer and collector are HTTP applications ("protocols" in twisted terminology) that can be configured to run on top of plain TCP, TLS, or onion service endpoints.
 Here is an example of the relevant part of the configuration::
     bouncer_endpoints:
-    - {type: tls, port: 10443, cert: "private/ssl-key-and-cert.pem"}
+    - {type: tls, port: 10443, cert: "private/fullchain.pem", privkey: "private/privkey.pem"}
     - {type: tcp, port: 10080}
     - {type: onion, hsdir: "/some/private/bouncer"}
 
     collector_endpoints:
-    - {type: tls, port: 11443, cert: "private/ssl-key-and-cert.pem"}
+    - {type: tls, port: 11443, fullchain: "private/fullchain.pem", privkey: "private/privkey.pem"}
     - {type: onion, hsdir: "/some/private/collector"}
 
 `scripts/gen-ssl-key-cert.sh` in this repo contains the openssl command to generate a self-signed certificate which you can use for the tls endpoint.


### PR DESCRIPTION
* This also changes the configuration to have to more options for tls
 endpoints (privkey and fullchain).

@anadahz noticed that with openssl versions > 0.9.8 if the server does not serve the full certificate chain it will fail validation.

This fix add support for specifying the full chain.