### PR TITLE
README.rst: also apt-get install libdumbnet-dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Distro dependencies (Debian)
 There are a few dependencies which we recommend you get from your
 distribution's archives::
 
-    sudo apt-get install build-essential python-dev python-setuptools openssl libsqlite3-dev libffi-dev git curl
+    sudo apt-get install build-essential python-dev python-setuptools openssl libsqlite3-dev libffi-dev git curl libdumbnet-dev
 
 Tor
 ...


### PR DESCRIPTION
Reported by @meejah in https://github.com/TheTorProject/ooni-backend/issues/107#issuecomment-297499759.