### PR TITLE
bouncer: implement /collector and /test-helpers

### DIFF
--- a/oonib/bouncer/api.py
+++ b/oonib/bouncer/api.py
@@ -2,6 +2,8 @@ from oonib.bouncer import handlers
 # XXX: if bouncer is configured
 bouncerAPI = [
     # return a collector and helper of the requested type
+    (r"/api/v1/collectors", handlers.APIv1Collectors),
+    (r"/api/v1/test-helpers", handlers.APIv1TestHelpers),
     (r"/bouncer", handlers.BouncerQueryHandler),
     (r"/bouncer/test-helpers", handlers.BouncerTestHelpers),
     (r"/bouncer/net-tests", handlers.BouncerNetTests),

--- a/oonib/bouncer/api.py
+++ b/oonib/bouncer/api.py
@@ -1,7 +1,6 @@
 from oonib.bouncer import handlers
 # XXX: if bouncer is configured
 bouncerAPI = [
-    # return a collector and helper of the requested type
     (r"/api/v1/collectors", handlers.APIv1Collectors),
     (r"/api/v1/test-helpers", handlers.APIv1TestHelpers),
     (r"/bouncer", handlers.BouncerQueryHandler),

--- a/oonib/bouncer/handlers.py
+++ b/oonib/bouncer/handlers.py
@@ -242,9 +242,7 @@ class APIv1Collectors(OONIBHandler):
         self.bouncer = Bouncer(config.main.bouncer_file)
 
     def get(self):
-        self.write({
-            "results": self.bouncer.formatCollectorsWithoutPolicy()
-        })
+        self.write(self.bouncer.formatCollectorsWithoutPolicy())
 
 
 class APIv1TestHelpers(OONIBHandler):
@@ -252,9 +250,7 @@ class APIv1TestHelpers(OONIBHandler):
         self.bouncer = Bouncer(config.main.bouncer_file)
 
     def get(self):
-        self.write({
-            "results": self.bouncer.formatTestHelpersWithoutPolicy()
-        })
+        self.write(self.bouncer.formatTestHelpersWithoutPolicy())
 
 
 class BouncerHandlerBase(OONIBHandler):

--- a/oonib/bouncer/handlers.py
+++ b/oonib/bouncer/handlers.py
@@ -201,11 +201,9 @@ class Bouncer(object):
             info = section.get(collector)
             if not info: continue
             for alt in info['collector-alternate']:
-                r = {}
-                for k in ('type', 'address', 'front'): r[k] = alt.get(k)
-                if not r['type'] or not r['address']: continue
-                if not r['front']: del r['front']
-                results.append(r)
+                r = self.format_alternate_address(alt)
+                if r:
+                    results.append(r)
         return results
 
     def formatTestHelpersWithoutPolicy(self):
@@ -229,12 +227,23 @@ class Bouncer(object):
                 for k, v in alt.items():
                     results.setdefault(k, [])
                     for e in v:
-                        r = {}
-                        for x in ('type', 'address', 'front'): r[x] = e.get(x)
-                        if not r['type'] or not r['address']: continue
-                        if not r['front']: del r['front']
-                        results[k].append(r)
+                        r = self.format_alternate_address(e)
+                        if r:
+                            results[k].append(r)
         return results
+
+    @staticmethod
+    def format_alternate_address(entry):
+        res = {
+            'type': entry.get('type'),
+            'address': entry.get('address'),
+            'front': entry.get('front'),
+        }
+        if not res['type'] or not res['address']:
+            return None  # reject invalid input with missing mandatory fields
+        if not res['front']:
+            del res['front']  # make sure we do not emit a None optional field
+        return res
 
 
 class APIv1Collectors(OONIBHandler):

--- a/oonib/tests/test_bouncer.py
+++ b/oonib/tests/test_bouncer.py
@@ -6,6 +6,7 @@ from twisted.internet import defer
 from cyclone import web
 
 from oonib.bouncer.api import bouncerAPI
+from oonib.bouncer.handlers import Bouncer
 from oonib.tests.handler_helpers import HandlerTestCase
 
 fake_bouncer_file = """
@@ -106,6 +107,23 @@ helpers:
          attribute: value
 """ % (reports_dir, archive_dir, input_dir, decks_dir, bouncer_filename)
 
+
+class FormatHelperAddressTest(HandlerTestCase):
+    def test_behaviour(self):
+        vector = (
+            ({}, None),
+            ({'type': 'https'}, None),
+            ({'address': 'https://a.org'}, None),
+            ({'address': 'https://a.org', 'type': 'https'},
+             {'address': 'https://a.org', 'type': 'https'}),
+            ({'address': 'https://a.org',
+              'type': 'cloudfront', 'front': 'aaa'},
+             {'address': 'https://a.org',
+              'type': 'cloudfront', 'front': 'aaa'}),
+        )
+        for inputs, expects in vector:
+            outputs = Bouncer.format_alternate_address(inputs)
+        self.assertEqual(expects, outputs)
 
 class BaseTestBouncer(HandlerTestCase):
     def setUp(self, *args, **kw):

--- a/oonib/tests/test_bouncer.py
+++ b/oonib/tests/test_bouncer.py
@@ -575,7 +575,7 @@ class TestProductionTests(BaseTestBouncer):
     def test_collectors(self):
         response = yield self.request('/api/v1/collectors', 'GET', None)
         response_body = json.loads(response.body)
-        self.assertEqual(response_body['results'], [{
+        self.assertEqual(response_body, [{
             "address": "httpo://ihiderha53f36lsd.onion",
             "type": "onion",
         }, {
@@ -591,7 +591,7 @@ class TestProductionTests(BaseTestBouncer):
     def test_test_helpers(self):
         response = yield self.request('/api/v1/test-helpers', 'GET', None)
         response_body = json.loads(response.body)
-        self.assertEqual(response_body['results'], {
+        self.assertEqual(response_body, {
             "dns": [{"type": "legacy", "address": "213.138.109.232:57004"}],
             "http-return-json-headers": [{
                 "type": "legacy",

--- a/oonib/tests/test_bouncer.py
+++ b/oonib/tests/test_bouncer.py
@@ -571,4 +571,54 @@ class TestProductionTests(BaseTestBouncer):
         response_body = json.loads(response.body)
         print(response_body['net-tests'])
 
+    @defer.inlineCallbacks
+    def test_collectors(self):
+        response = yield self.request('/api/v1/collectors', 'GET', None)
+        response_body = json.loads(response.body)
+        self.assertEqual(response_body['results'], [{
+            "address": "httpo://ihiderha53f36lsd.onion",
+            "type": "onion",
+        }, {
+            "address": "https://a.collector.ooni.io:4441",
+            "type": "https"
+        }, {
+            "address": "https://das0y2z2ribx3.cloudfront.net",
+            "front": "a0.awsstatic.com",
+            "type": "cloudfront"
+        }])
+
+    @defer.inlineCallbacks
+    def test_test_helpers(self):
+        response = yield self.request('/api/v1/test-helpers', 'GET', None)
+        response_body = json.loads(response.body)
+        self.assertEqual(response_body['results'], {
+            "dns": [{"type": "legacy", "address": "213.138.109.232:57004"}],
+            "http-return-json-headers": [{
+                "type": "legacy",
+                "address": "http://38.107.216.10:80"
+            }],
+            "ssl": [{
+                "type": "legacy",
+                "address": "https://213.138.109.232"
+            }],
+            "tcp-echo": [{
+                "type": "legacy",
+                "address": "213.138.109.232"
+            }],
+            "traceroute": [{
+                "type": "legacy",
+                "address": "213.138.109.232"
+            }],
+            "web-connectivity": [{
+                "type": "legacy",
+                "address": "httpo://7jne2rpg5lsaqs6b.onion"
+            }, {
+                "address": "https://a.web-connectivity.th.ooni.io:4442",
+                "type": "https",
+            }, {
+                "address": "https://d2vt18apel48hw.cloudfront.net",
+                "front": "a0.awsstatic.com",
+                "type": "cloudfront",
+            }]
+        })
 


### PR DESCRIPTION
This allows us to deploy a bouncer with a much simpler API. So, we can
start using such better API in apps. This makes us ready to switch to
use the OONI orchestra rather than legacy services, since the API added
here is the same API of some OONI orchestra endpoints.